### PR TITLE
Fix launching FHIR server

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -38,7 +38,7 @@
                                            ca.uhn.hapi.fhir/hapi-fhir-server        {:mvn/version "5.3.0"}
                                            ca.uhn.hapi.fhir/hapi-fhir-structures-r4 {:mvn/version "5.3.0"}
                                            ch.qos.logback/logback-classic           {:mvn/version "1.2.3"}}
-                             :main-opts   ["-m " com.eldrix.clods.fhir.r4.serve]}
+                             :main-opts   ["-m" "com.eldrix.clods.fhir.r4.serve"]}
 
            :test            {:extra-paths ["test" "test/resources"]
                              :extra-deps  {com.cognitect/test-runner {:git/url "https://github.com/cognitect-labs/test-runner.git"


### PR DESCRIPTION
This small change allows me to launch the FHIR server on my machine with:

```shell
clj -M:fhir-r4   target/ods-2021-02 ../nhspd/target/nhspd-2021-02 8080
```

I'm not at all familiar with clojure or the 'edn' file format, but this seemed to work for me.

My environment:
> MacOS 11.2.3 (20D91)
> zsh 5.8 (x86_64-apple-darwin20.1.0)
> Clojure CLI version 1.10.3.814
> openjdk 11.0.10 2021-01-19